### PR TITLE
Update url & search on title and author only

### DIFF
--- a/engines/audiobookbay.py
+++ b/engines/audiobookbay.py
@@ -26,7 +26,7 @@ from html.parser import HTMLParser
 import urllib.parse
 
 class audiobookbay(object):
-    url = 'http://audiobookbay.fi'
+    url = 'http://audiobookbay.is'
     name = 'AudioBook Bay (ABB)'
     supported_categories = {'all': 'all'}
 
@@ -168,7 +168,7 @@ class audiobookbay(object):
 
 
     def request(self, searchTerm, category, page=1):
-        return retrieve_url(self.url + '/page/'+str(page)+'?s='+searchTerm+'&cat='+category)
+        return retrieve_url(self.url + '/page/'+str(page)+'?s='+searchTerm+'&tt=1')
 
     def search(self, what, cat='all'):
         category = self.supported_categories[cat]


### PR DESCRIPTION
Update url to .is since the current url being used is blocked in a lot of countries
Also search without category, and changed to search on the title and author. Reason being the search result from title and author is more accurate if you know the audiobook title